### PR TITLE
Do not use MiniCssExtractPlugin

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,14 +12,6 @@ module ApplicationHelper
     javascript_include_tag('', **options)
   end
 
-  def stylesheet_bundle_tag(entry, **options)
-    options = {
-      href: asset_bundle_tag("#{entry}.css")
-    }.merge(options)
-
-    stylesheet_link_tag '', options
-  end
-
   # app/frontend/images/avatar.png を表示したいとき
   #   image_tag("avatar")
   #   # => <img src="/bundle/avatar" />

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <%= csp_meta_tag %>
 
     <%= javascript_bundle_tag 'hello_world' %>
-    <%= stylesheet_bundle_tag 'style' %>
+    <%= javascript_bundle_tag 'style' %>
   </head>
 
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3022,12 +3022,6 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
-    "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true
-    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -3396,18 +3390,6 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
-    "mini-css-extract-plugin": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.6.0.tgz",
-      "integrity": "sha512-79q5P7YGI6rdnVyIAV4NXpBQJFWdkzJxCim3Kog4078fM0piAaFlwocqbejdWtLW1cEzCexPrh6EdyFsPgVdAw==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.1.0",
-        "normalize-url": "^2.0.1",
-        "schema-utils": "^1.0.0",
-        "webpack-sources": "^1.1.0"
-      }
-    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -3760,17 +3742,6 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
-    },
-    "normalize-url": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
-      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
-      "dev": true,
-      "requires": {
-        "prepend-http": "^2.0.0",
-        "query-string": "^5.0.1",
-        "sort-keys": "^2.0.0"
-      }
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -4203,12 +4174,6 @@
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
       "dev": true
     },
-    "prepend-http": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-      "dev": true
-    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -4303,17 +4268,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
-    },
-    "query-string": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-      "dev": true,
-      "requires": {
-        "decode-uri-component": "^0.2.0",
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
-      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -5097,15 +5051,6 @@
         }
       }
     },
-    "sort-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-      "dev": true,
-      "requires": {
-        "is-plain-obj": "^1.0.0"
-      }
-    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -5301,12 +5246,6 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
-    "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-      "dev": true
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -5357,6 +5296,16 @@
       "dev": true,
       "requires": {
         "get-stdin": "^4.0.1"
+      }
+    },
+    "style-loader": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.23.1.tgz",
+      "integrity": "sha512-XK+uv9kWwhZMZ1y7mysB+zoihsEj4wneFWAS5qoiLwzW0WzSqMrrsIy+a3zkQJq0ipFtBpX5W3MqyRIBF/WFGg==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "schema-utils": "^1.0.0"
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "devDependencies": {
     "css-loader": "^2.1.1",
     "file-loader": "^3.0.1",
-    "mini-css-extract-plugin": "^0.6.0",
     "node-sass": "^4.12.0",
     "sass-loader": "^7.1.0",
     "source-map-loader": "^0.2.4",
+    "style-loader": "^0.23.1",
     "ts-loader": "^6.0.1",
     "typescript": "^3.4.5",
     "webpack": "^4.32.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 const path = require("path");
 const ManifestPlugin = require("webpack-manifest-plugin");
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 module.exports = (_, argv) => {
   const isProduction = argv.mode === "production";
@@ -34,7 +33,7 @@ module.exports = (_, argv) => {
         {
           test: /\.scss$/,
           use: [
-            MiniCssExtractPlugin.loader,
+            "style-loader",
             "css-loader",
             "sass-loader"
           ]
@@ -61,9 +60,6 @@ module.exports = (_, argv) => {
     plugins: [
       // asset manifestファイルを作成する
       new ManifestPlugin({ fileName: "webpack-manifest.json" }),
-
-      // CSSファイルを作成する
-      new MiniCssExtractPlugin({filename: '[name].[contenthash].css'}),
     ]
 
   };


### PR DESCRIPTION
scss 中の url("") でファイルを指定しているとき
MiniCssExtractPlugin + file-loader + ManifestPlugin の組み合わせで、書き出される manifest 記載のファイルのキーがおかしくなる

MiniCssExtractPluginなし

```json
{
  "hello_world.js": "/bundle/hello_world.2dfc8c5e6cfb74c36337.js",
  "style.js": "/bundle/style.1fda575fe9fd01647842.js",
  "images/skyview.jpg": "/bundle/images/skyview.bf6a8ac49db7896747fa3b5c65cd71ba.jpg",
  "images/stripe.png": "/bundle/images/stripe.35fe2f287977b018dc2f3dcb9d4c04e5.png"
}
```

MiniCssExtractPluginあり

```
{
  "hello_world.js": "/bundle/hello_world.e7e00300dbeb8f1ca9aa.js",
  "style.css": "/bundle/style.1c30631677db21a2065c.css",
  "style.js": "/bundle/style.8ccf8124566c1d1dd259.js",
  "images/skyview.jpg": "/bundle/images/skyview.bf6a8ac49db7896747fa3b5c65cd71ba.jpg",
  "images/style.scss": "/bundle/images/stripe.35fe2f287977b018dc2f3dcb9d4c04e5.png"
}
```

`"images/style.scss":`

